### PR TITLE
Consuming response in case of prefetch

### DIFF
--- a/android-networking/src/main/java/com/androidnetworking/common/ANRequest.java
+++ b/android-networking/src/main/java/com/androidnetworking/common/ANRequest.java
@@ -595,7 +595,12 @@ public class ANRequest<T extends ANRequest> {
                     return ANResponse.failed(Utils.getErrorForParse(new ANError(e)));
                 }
             case PREFETCH:
-                return ANResponse.success(ANConstants.PREFETCH);
+                try {
+                    Okio.buffer(response.body().source()).skip(Long.MAX_VALUE);
+                    return ANResponse.success(ANConstants.PREFETCH);
+                } catch (Exception e) {
+                    return ANResponse.failed(Utils.getErrorForParse(new ANError(e)));
+                }
         }
         return null;
     }


### PR DESCRIPTION
Closing response can timeout and if that is the case the response will not be cached