### PR TITLE
add Logging Response Body feature

### DIFF
--- a/android-networking/src/main/java/com/androidnetworking/common/RequestBuilder.java
+++ b/android-networking/src/main/java/com/androidnetworking/common/RequestBuilder.java
@@ -66,4 +66,5 @@ public interface RequestBuilder {
 
     RequestBuilder setUserAgent(String userAgent);
 
+    RequestBuilder logResponseBody();
 }


### PR DESCRIPTION
Developer can now log the response body of a request by adding a method 'logResponseBody()' before '.build()' to any Request. This will help the developer to see the raw body before its parsed with the 'getAsObject' method. This feature is quite helpful when an invalid json is returned from server as at present, one has to see response by 'getAsString' method or he as to make use of some external rest client. One cannot see the raw response body after the json has been parsed in 'getAsObject' method because it simply falls in 'onError()' method.