### PR TITLE
fix: convert file name field to just name not full path #523

### DIFF
--- a/android-networking/src/main/java/com/androidnetworking/common/ANRequest.java
+++ b/android-networking/src/main/java/com/androidnetworking/common/ANRequest.java
@@ -867,7 +867,7 @@ public class ANRequest<T extends ANRequest> {
             for (HashMap.Entry<String, List<MultipartFileBody>> entry : mMultiPartFileMap.entrySet()) {
                 List<MultipartFileBody> fileBodies = entry.getValue();
                 for (MultipartFileBody fileBody : fileBodies) {
-                    String fileName = fileBody.file.getName();
+                    String fileName = fileBody.file.getName().substring(fileBody.file.getName().lastIndexOf("/") + 1);
                     MediaType mediaType;
                     if (fileBody.contentType != null) {
                         mediaType = MediaType.parse(fileBody.contentType);


### PR DESCRIPTION
instead of file name in requests, just use file name
with this change if file name is correct (and is not absolute path) nothing changes.