### PR TITLE
Fix : Slow server response. #616

### DIFF
--- a/app/src/main/java/com/networking/ApiTestActivity.java
+++ b/app/src/main/java/com/networking/ApiTestActivity.java
@@ -747,7 +747,7 @@ public class ApiTestActivity extends AppCompatActivity {
                 .addBodyParameter("firstname", "Amit")
                 .addBodyParameter("lastname", "Shekhar")
                 .setTag(this)
-                .setOkHttpClient(new OkHttpClient())
+                .setOkHttpClient(MyApplication.getInstance().getOkHttpClient())
                 .setPriority(Priority.LOW)
                 .build()
                 .setAnalyticsListener(new AnalyticsListener() {
@@ -789,7 +789,7 @@ public class ApiTestActivity extends AppCompatActivity {
         AndroidNetworking.download(url, Utils.getRootDirPath(getApplicationContext()), "file1.zip")
                 .setPriority(Priority.HIGH)
                 .setTag(this)
-                .setOkHttpClient(new OkHttpClient())
+                .setOkHttpClient(MyApplication.getInstance().getOkHttpClient())
                 .build()
                 .setAnalyticsListener(new AnalyticsListener() {
                     @Override

--- a/app/src/main/java/com/networking/MyApplication.java
+++ b/app/src/main/java/com/networking/MyApplication.java
@@ -25,6 +25,10 @@ import com.androidnetworking.AndroidNetworking;
 import com.androidnetworking.common.ConnectionQuality;
 import com.androidnetworking.interfaces.ConnectionQualityChangeListener;
 
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+
 /**
  * Created by amitshekhar on 22/03/16.
  */
@@ -32,16 +36,27 @@ public class MyApplication extends Application {
 
     private static final String TAG = MyApplication.class.getSimpleName();
     private static MyApplication appInstance = null;
+    private OkHttpClient okHttpClient;
 
     public static MyApplication getInstance() {
         return appInstance;
+    }
+
+    public OkHttpClient getOkHttpClient() {
+        return okHttpClient;
     }
 
     @Override
     public void onCreate() {
         super.onCreate();
         appInstance = this;
-        AndroidNetworking.initialize(getApplicationContext());
+        okHttpClient = new OkHttpClient.Builder()
+                .connectTimeout(120, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .writeTimeout(120, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .build();
+        AndroidNetworking.initialize(getApplicationContext(), okHttpClient);
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inPurgeable = true;
         AndroidNetworking.setBitmapDecodeOptions(options);

--- a/app/src/main/java/com/networking/OkHttpResponseTestActivity.java
+++ b/app/src/main/java/com/networking/OkHttpResponseTestActivity.java
@@ -695,7 +695,7 @@ public class OkHttpResponseTestActivity extends AppCompatActivity {
                 .addBodyParameter("firstname", "Amit")
                 .addBodyParameter("lastname", "Shekhar")
                 .setTag(this)
-                .setOkHttpClient(new OkHttpClient())
+                .setOkHttpClient(MyApplication.getInstance().getOkHttpClient())
                 .setPriority(Priority.LOW)
                 .build()
                 .setAnalyticsListener(new AnalyticsListener() {
@@ -731,7 +731,7 @@ public class OkHttpResponseTestActivity extends AppCompatActivity {
         AndroidNetworking.download(url, Utils.getRootDirPath(getApplicationContext()), "file1.zip")
                 .setPriority(Priority.HIGH)
                 .setTag(this)
-                .setOkHttpClient(new OkHttpClient())
+                .setOkHttpClient(MyApplication.getInstance().getOkHttpClient())
                 .build()
                 .setAnalyticsListener(new AnalyticsListener() {
                     @Override

--- a/rx2sampleapp/src/main/java/com/rx2sampleapp/Rx2MyApplication.java
+++ b/rx2sampleapp/src/main/java/com/rx2sampleapp/Rx2MyApplication.java
@@ -23,10 +23,15 @@ import com.androidnetworking.AndroidNetworking;
 import com.androidnetworking.common.ConnectionQuality;
 import com.androidnetworking.interfaces.ConnectionQualityChangeListener;
 
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+
 public class Rx2MyApplication extends Application {
 
     private static final String TAG = Rx2MyApplication.class.getSimpleName();
     private static Rx2MyApplication appInstance = null;
+    private OkHttpClient okHttpClient;
 
     public static Rx2MyApplication getInstance() {
         return appInstance;
@@ -36,7 +41,13 @@ public class Rx2MyApplication extends Application {
     public void onCreate() {
         super.onCreate();
         appInstance = this;
-        AndroidNetworking.initialize(getApplicationContext());
+        okHttpClient = new OkHttpClient.Builder()
+                .connectTimeout(120, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .writeTimeout(120, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .build();
+        AndroidNetworking.initialize(getApplicationContext(), okHttpClient);
         AndroidNetworking.enableLogging();
         AndroidNetworking.setConnectionQualityChangeListener(new ConnectionQualityChangeListener() {
             @Override

--- a/rxsampleapp/src/main/java/com/rxsampleapp/RxMyApplication.java
+++ b/rxsampleapp/src/main/java/com/rxsampleapp/RxMyApplication.java
@@ -23,10 +23,15 @@ import com.androidnetworking.AndroidNetworking;
 import com.androidnetworking.common.ConnectionQuality;
 import com.androidnetworking.interfaces.ConnectionQualityChangeListener;
 
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+
 public class RxMyApplication extends Application {
 
     private static final String TAG = RxMyApplication.class.getSimpleName();
     private static RxMyApplication appInstance = null;
+    private OkHttpClient okHttpClient;
 
     public static RxMyApplication getInstance() {
         return appInstance;
@@ -36,7 +41,13 @@ public class RxMyApplication extends Application {
     public void onCreate() {
         super.onCreate();
         appInstance = this;
-        AndroidNetworking.initialize(getApplicationContext());
+        okHttpClient = new OkHttpClient.Builder()
+                .connectTimeout(120, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .writeTimeout(120, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .build();
+        AndroidNetworking.initialize(getApplicationContext(), okHttpClient);
         AndroidNetworking.enableLogging();
         AndroidNetworking.setConnectionQualityChangeListener(new ConnectionQualityChangeListener() {
             @Override


### PR DESCRIPTION
I added a global OkHttpClient with long timeouts and initialized AndroidNetworking with it.
I replaced per-request new OkHttpClient() usages with the shared client to avoid overriding the longer timeouts.
I aligned the Rx sample apps to initialize with the same client.

Updated app/src/main/java/com/networking/MyApplication.java to build an OkHttpClient with 120s connect/read/write timeouts and pass it to AndroidNetworking.initialize(...). Exposed getOkHttpClient() to reuse.

Updated per-request overrides in app:
- app/src/main/java/com/networking/ApiTestActivity.java (2 spots) to use MyApplication.getInstance().getOkHttpClient().
- app/src/main/java/com/networking/OkHttpResponseTestActivity.java (2 spots) to use the same shared client.
Updated Rx sample apps to use the same approach:
- rxsampleapp/src/main/java/com/rxsampleapp/RxMyApplication.java
- rx2sampleapp/src/main/java/com/rx2sampleapp/Rx2MyApplication.java

Contribution by Gittensor, learn more at https://gittensor.io/

This ensures slow server responses (50–60s) won’t trigger premature onError due to client-side timeouts.